### PR TITLE
unexpected array merge result

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ return function deepmerge(target, src) {
         src.forEach(function(e, i) {
             if (typeof dst[i] === 'undefined') {
                 dst[i] = e;
-            } else if (typeof e === 'object') {
-                dst[i] = deepmerge(target[i], e);
-            } else {
+            } else if (typeof e !== 'object' || typeof target[i] !== 'object') {
                 if (target.indexOf(e) === -1) {
                     dst.push(e);
                 }
+            } else {
+                dst[i] = deepmerge(target[i], e);
             }
         });
     } else {

--- a/test/merge.js
+++ b/test/merge.js
@@ -152,6 +152,22 @@ test('should work on another simple array', function(t) {
     t.end()
 })
 
+
+
+test('should push on array when is missing value', function (t) {
+
+    var target = ["foo","bar"]
+    
+    var src = [{"baz":"qux"}]
+
+    var expected = ["foo", "bar", {"baz":"qux"}]
+
+    t.deepEqual(target, ["foo","bar"])
+    t.deepEqual(merge(target, src), expected)
+
+    t.end()
+})
+
 test('should work on array properties', function (t) {
     var src = {
         key1: ['one', 'three'],


### PR DESCRIPTION
deepmerge( ["foo", "bar"], [{"baz":"qux"}] ) should return ["foo", "bar", {"baz":"qux"}] and not [{"baz":"qux"}, "bar"]
