### PR TITLE
Add generic type overwrite to deepmerge.all

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace deepmerge {
 	}
 
 	export function all (objects: object[], options?: Options): object;
+	export function all<T> (objects: Partial<T>[], options?: Options): T;
 }
 
 export = deepmerge;

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -3,26 +3,31 @@ import * as merge from '../';
 const x = {
 	foo: 'abc',
 	bar: 'def',
+	wat: 42,
 }
 
 const y = {
 	foo: 'cba',
 	bar: 'fed',
+	wat: 42,
 }
 
 const z = {
 	baz: '123',
 	quux: '456',
+	wat: 42,
 }
 
 let merged1 = merge(x, y);
 let merged2 = merge(x, z);
-let merged3 = merge.all([ x, y, z ]);
+let merged3 = merge.all<{wat: number}>([ x, y, z ]);
 
 merged1.foo;
 merged1.bar;
 merged2.foo;
 merged2.baz;
+merged3.wat;
+
 
 const options1: merge.Options = {
 	clone: true,
@@ -47,4 +52,4 @@ const options2: merge.Options = {
 
 merged1 = merge(x, y, options1);
 merged2 = merge(x, z, options2);
-merged3 = merge.all([x, y, z], options1);
+merged3 = merge.all<{wat: number}>([x, y, z], options1);


### PR DESCRIPTION
Hey,

Thank you for this great library, I just happened to have a case where `deepmerge.all` came in handy and I wanted to have the types set up right, so this is why I would need this change.