### PR TITLE
all is now generic and returns type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace deepmerge {
 		isMergeableObject?(value: object): boolean;
 	}
 
-	export function all (objects: object[], options?: Options): object;
+	export function all<T>(objects: object | T[], options?: Options): T;
 }
 
 export = deepmerge;


### PR DESCRIPTION
In typescript I've been pushed into implementing something like:

```typescript
type Foo {
  a: string;
  b: number;
}

const a = {
  a: "hello",
  b: 2
}

const b = {
 b: 1
}

const c = deepmerge.all([a, b]) as Foo;
```

this PR would change the output to be something closer to allowing `Foo` to be inferable