### PR TITLE
Allow merging object with symbol keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,21 @@ function getMergeFunction(key, options) {
 function mergeObject(target, source, options) {
 	var destination = {}
 	if (options.isMergeableObject(target)) {
-		Object.keys(target).forEach(function(key) {
+		Object.getOwnPropertySymbols(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
+		})
+		Object.getOwnPropertyNames(target).forEach(function(key) {
 			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
 		})
 	}
-	Object.keys(source).forEach(function(key) {
+	Object.getOwnPropertySymbols(source).forEach(function(key) {
+		if (!options.isMergeableObject(source[key]) || !target[key]) {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
+		} else {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
+		}
+	})
+	Object.getOwnPropertyNames(source).forEach(function(key) {
 		if (!options.isMergeableObject(source[key]) || !target[key]) {
 			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
 		} else {

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,6 +1,17 @@
 var merge = require('../')
 var test = require('tap').test
 
+test('work with symbol keys', function(t) {
+	var src = { [Symbol.for('key1')]: 'value1' }
+	var target = {}
+
+	var res = merge(target, src)
+
+	t.deepEqual(target, {}, 'merge should be immutable')
+	t.equal(res[Symbol.for('key1')], src[Symbol.for('key1')])
+	t.end()
+})
+
 test('add keys in target that do not exist at the root', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = {}


### PR DESCRIPTION
I discovered today that:
* object keys are not restricted to string values.
* `Object.keys` only show the string keys.

Currently the symbol keys are being ignored.
This PR will allow merging objects with symbol keys.

Let me know if I should make any change to the code.
BTW, Great work with the library :clap: 