### PR TITLE
Drop Node v6 and v11, add Node v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "11"
+  - "12"
   - "10"
   - "8"
-  - "6"


### PR DESCRIPTION
v6 ended in April 2019.
v8 will end soon on June 1, 2019.
https://github.com/nodejs/Release