### PR TITLE
Copy own __proto__ safely

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function mergeObject(target, source, options) {
 	getKeys(source).forEach(function(key) {
 		if (!propertyIsPlain(target, key)) {
 			return
-	}
+		}
 
 		if (!options.isMergeableObject(source[key]) || !target[key]) {
 			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)

--- a/index.js
+++ b/index.js
@@ -36,18 +36,31 @@ function getKeys(target) {
 	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
 }
 
+function setProperty(target, key, value) {
+	if (key === '__proto__') {
+		Object.defineProperty(target, key, {
+			enumerable: true,
+			configurable: true,
+			value: value,
+			writable: true
+		})
+	} else {
+		target[key] = value
+	}
+}
+
 function mergeObject(target, source, options) {
 	var destination = {}
 	if (options.isMergeableObject(target)) {
 		getKeys(target).forEach(function(key) {
-			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
+			setProperty(destination, key, cloneUnlessOtherwiseSpecified(target[key], options))
 		})
 	}
 	getKeys(source).forEach(function(key) {
 		if (!options.isMergeableObject(source[key]) || !target[key]) {
-			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
+			setProperty(destination, key, cloneUnlessOtherwiseSpecified(source[key], options))
 		} else {
-			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
+			setProperty(destination, key, getMergeFunction(key, options)(target[key], source[key], options))
 		}
 	})
 	return destination

--- a/index.js
+++ b/index.js
@@ -37,8 +37,14 @@ function getKeys(target) {
 }
 
 function propertyIsPlain(target, key) {
-	return target[key] === undefined
-		|| (target.hasOwnProperty(key) && target.propertyIsEnumerable(key))
+	var keyInTarget
+	try {
+		keyInTarget = (key in target)
+	} catch (unused) {
+		keyInTarget = false
+	}
+
+	return !keyInTarget || (target.hasOwnProperty(key) && target.propertyIsEnumerable(key))
 }
 
 function mergeObject(target, source, options) {

--- a/index.js
+++ b/index.js
@@ -36,31 +36,27 @@ function getKeys(target) {
 	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
 }
 
-function setProperty(target, key, value) {
-	if (key === '__proto__') {
-		Object.defineProperty(target, key, {
-			enumerable: true,
-			configurable: true,
-			value: value,
-			writable: true
-		})
-	} else {
-		target[key] = value
-	}
+function propertyIsPlain(target, key) {
+	return target[key] === undefined
+		|| (target.hasOwnProperty(key) && target.propertyIsEnumerable(key))
 }
 
 function mergeObject(target, source, options) {
 	var destination = {}
 	if (options.isMergeableObject(target)) {
 		getKeys(target).forEach(function(key) {
-			setProperty(destination, key, cloneUnlessOtherwiseSpecified(target[key], options))
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
 		})
 	}
 	getKeys(source).forEach(function(key) {
+		if (!propertyIsPlain(target, key)) {
+			return
+	}
+
 		if (!options.isMergeableObject(source[key]) || !target[key]) {
-			setProperty(destination, key, cloneUnlessOtherwiseSpecified(source[key], options))
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
 		} else {
-			setProperty(destination, key, getMergeFunction(key, options)(target[key], source[key], options))
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
 		}
 	})
 	return destination

--- a/index.js
+++ b/index.js
@@ -36,15 +36,10 @@ function getKeys(target) {
 	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
 }
 
-function propertyIsPlain(target, key) {
-	var keyInTarget
-	try {
-		keyInTarget = (key in target)
-	} catch (unused) {
-		keyInTarget = false
-	}
-
-	return !keyInTarget || (target.hasOwnProperty(key) && target.propertyIsEnumerable(key))
+// Protects from prototype poisoning. '__proto__' is one of few truthy non-enumerable
+// properties.
+function propertyIsUnsafe(target, key) {
+	return target && target[key] && !Object.propertyIsEnumerable.call(target, key)
 }
 
 function mergeObject(target, source, options) {
@@ -55,7 +50,7 @@ function mergeObject(target, source, options) {
 		})
 	}
 	getKeys(source).forEach(function(key) {
-		if (!propertyIsPlain(target, key)) {
+		if (propertyIsUnsafe(target, key)) {
 			return
 		}
 

--- a/test/prototype-poisoning.js
+++ b/test/prototype-poisoning.js
@@ -5,7 +5,32 @@ test('merging objects with own __proto__', function(t) {
 	var user = {}
 	var malicious = JSON.parse('{ "__proto__": { "admin": true } }')
 	var mergedObject = merge(user, malicious)
-	t.ok(mergedObject.__proto__.admin, 'nested properties should be merged')
-	t.notOk(mergedObject.admin, 'the destination should have an unchanged prototype')
+	t.notOk(mergedObject.__proto__.admin, 'non-plain properties should not be merged')
+	t.notOk(mergedObject.admin, 'the destination should have an unmodified prototype')
+	t.end()
+})
+
+test('merging objects with plain and non-plain properties', function(t) {
+	var plainSymbolKey = Symbol('plainSymbolKey')
+	var parent = {
+		parentKey: 'should be undefined'
+	}
+	
+	var target = Object.create(parent)	
+	target.plainKey = 'should be replaced'
+	target[plainSymbolKey] = 'should also be replaced'
+	
+	var source = {
+		parentKey: 'foo',
+		plainKey: 'bar',
+		newKey: 'baz',
+		[plainSymbolKey]: 'qux'
+	}
+	
+	var mergedObject = merge(target, source)
+	t.equal(undefined, mergedObject.parentKey, 'inherited properties of target should be removed, not merged or ignored')
+	t.equal('bar', mergedObject.plainKey, 'enumerable own properties of target should be merged')
+	t.equal('baz', mergedObject.newKey, 'properties not yet on target should be merged')
+	t.equal('qux', mergedObject[plainSymbolKey], 'enumerable own symbol properties of target should be merged')
 	t.end()
 })

--- a/test/prototype-poisoning.js
+++ b/test/prototype-poisoning.js
@@ -1,0 +1,11 @@
+var merge = require('../')
+var test = require('tape')
+
+test('merging objects with own __proto__', function(t) {
+	var user = {}
+	var malicious = JSON.parse('{ "__proto__": { "admin": true } }')
+	var mergedObject = merge(user, malicious)
+	t.ok(mergedObject.__proto__.admin, 'nested properties should be merged')
+	t.notOk(mergedObject.admin, 'the destination should have an unchanged prototype')
+	t.end()
+})

--- a/test/prototype-poisoning.js
+++ b/test/prototype-poisoning.js
@@ -1,5 +1,6 @@
 var merge = require('../')
 var test = require('tape')
+var isMergeableObject = require('is-mergeable-object')
 
 test('merging objects with own __proto__', function(t) {
 	var user = {}
@@ -32,5 +33,46 @@ test('merging objects with plain and non-plain properties', function(t) {
 	t.equal('bar', mergedObject.plainKey, 'enumerable own properties of target should be merged')
 	t.equal('baz', mergedObject.newKey, 'properties not yet on target should be merged')
 	t.equal('qux', mergedObject[plainSymbolKey], 'enumerable own symbol properties of target should be merged')
+	t.end()
+})
+
+// the following cases come from the thread here: https://github.com/TehShrike/deepmerge/pull/164
+test('merging strings works with a custom string merge', function(t) {
+	var target = { name: "Alexander" }
+	var source = { name: "Hamilton" }
+	function customMerge(key, options) {
+		if (key === 'name') {
+			return function(target, source, options) {
+				return target[0] + '. ' + source.substring(0, 3)
+			}
+		} else {
+			return merge
+		}
+	}
+
+	function mergeable(target) {
+		return isMergeableObject(target) || (typeof target === 'string' && target.length > 1)
+	}
+
+	t.equal('A. Ham', merge(target, source, { customMerge: customMerge, isMergeableObject: mergeable }).name)
+	t.end()
+})
+
+test('merging objects with null prototype', function(t) {
+	var target = Object.create(null)
+	var source = Object.create(null)
+	target.wheels = 4
+	target.trunk = { toolbox: ['hammer'] }
+	source.trunk = { toolbox: ['wrench'] }
+	source.engine = 'v8'
+	var expected = {
+		wheels: 4,
+		engine: 'v8',
+		trunk: {
+			toolbox: ['hammer', 'wrench' ]
+		}
+	}
+
+	t.deepEqual(expected, merge(target, source))
 	t.end()
 })


### PR DESCRIPTION
- When the src object has an own __proto__ property, avoid
modifying the result object's prototype