### PR TITLE
Expose cloneUnlessOtherwiseSpecified to array merge function

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ function deepmerge(target, source, options) {
 	options = options || {}
 	options.arrayMerge = options.arrayMerge || defaultArrayMerge
 	options.isMergeableObject = options.isMergeableObject || defaultIsMergeableObject
+	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+	// implementations can use it. The caller may not replace it.
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified
 
 	var sourceIsArray = Array.isArray(source)
 	var targetIsArray = Array.isArray(target)

--- a/test/custom-array-merge.js
+++ b/test/custom-array-merge.js
@@ -38,3 +38,33 @@ test('merge top-level arrays', function(t) {
 	t.deepEqual(actual, expected)
 	t.end()
 })
+
+test('cloner function is available for merge functions to use', function(t) {
+	var customMergeWasCalled = false
+	function cloneMerge(target, source, options) {
+		customMergeWasCalled = true
+		t.ok(options.cloneUnlessOtherwiseSpecified, 'cloner function is available')
+		return target.concat(source).map(function(element) {
+			return options.cloneUnlessOtherwiseSpecified(element, options)
+		})
+	}
+
+	var src = {
+		key1: [ 'one', 'three' ],
+		key2: [ 'four' ],
+	}
+	var target = {
+		key1: [ 'one', 'two' ],
+	}
+
+	var expected = {
+		key1: [ 'one', 'two', 'one', 'three' ],
+		key2: [ 'four' ],
+	}
+
+	t.deepEqual(merge(target, src, { arrayMerge: cloneMerge }), expected)
+	t.ok(customMergeWasCalled)
+	t.ok(Array.isArray(merge(target, src).key1))
+	t.ok(Array.isArray(merge(target, src).key2))
+	t.end()
+})


### PR DESCRIPTION
- Custom arrayMerge implementations can call options.cloneUnlessOtherwiseSpecified to use
the default clone function

#85