### PR TITLE
Stops mutating options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,10 @@ function mergeObject(target, source, options) {
 }
 
 function deepmerge(target, source, options) {
-	options = options || {}
-	options.arrayMerge = options.arrayMerge || defaultArrayMerge
-	options.isMergeableObject = options.isMergeableObject || defaultIsMergeableObject
+	options = Object.assign({}, { 
+		arrayMerge: defaultArrayMerge, 
+		isMergeableObject: defaultIsMergeableObject 
+	}, options);
 	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
 	// implementations can use it. The caller may not replace it.
 	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified

--- a/test/merge.js
+++ b/test/merge.js
@@ -637,3 +637,12 @@ test('copy symbol keys in target that do exist on the target', function(t) {
 	t.equal(res[mySymbol], 'value1')
 	t.end()
 })
+
+test('should not mutate options', function(t) {
+	var options = {};
+
+	merge({}, {}, options);
+
+	t.deepEqual(options, {});
+	t.end();
+})


### PR DESCRIPTION
fixes #166 

Uses `Object.assign()` when setting default options, to avoid mutating passed-in options object. 

Adds test to ensure options object isn't mutated. 