### PR TITLE
Avoid mutating options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # [5.0.0](https://github.com/TehShrike/deepmerge/releases/tag/v5.0.0)
 
-- Breaking: Dropped ES5 support. [#161](https://github.com/TehShrike/deepmerge/issues/161)
+- Breaking: The shipped bundle now targets ES2015 instead of ES5.  If you target IE11, you'll need to change your build process to compile dependencies. [#161](https://github.com/TehShrike/deepmerge/issues/161)
 - Breaking: by default, only [plain objects](https://github.com/sindresorhus/is-plain-obj/#is-plain-obj-) will have their properties merged, with all other values being copied to the target.  [#152](https://github.com/TehShrike/deepmerge/issues/152)
 - Breaking: the `isMergeableObject` option is renamed to `isMergeable` [#168](https://github.com/TehShrike/deepmerge/pull/168)
+- Fixed: the options argument is no longer mutated (again) [#173](https://github.com/TehShrike/deepmerge/pull/173)
 
 # [4.2.2](https://github.com/TehShrike/deepmerge/releases/tag/v4.2.2)
 

--- a/index.js
+++ b/index.js
@@ -72,13 +72,16 @@ function mergeObject(target, source, options) {
 	return destination
 }
 
-function deepmerge(target, source, options) {
-	options = options || {}
-	options.arrayMerge = options.arrayMerge || defaultArrayMerge
-	options.isMergeableObject = options.isMergeableObject || defaultIsMergeableObject
-	// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
-	// implementations can use it. The caller may not replace it.
-	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified
+function deepmerge(target, source, opts) {
+	var options = {
+		clone: opts && opts.clone,
+		customMerge: opts && opts.customMerge,
+		arrayMerge: (opts && opts.arrayMerge) || defaultArrayMerge,
+		isMergeableObject: (opts && opts.isMergeableObject) || defaultIsMergeableObject,
+		// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
+		// implementations can use it. The caller may not replace it.
+		cloneUnlessOtherwiseSpecified: cloneUnlessOtherwiseSpecified
+	}
 
 	var sourceIsArray = Array.isArray(source)
 	var targetIsArray = Array.isArray(target)

--- a/index.js
+++ b/index.js
@@ -70,12 +70,11 @@ const mergeObject = (target, source, options) => {
 	return destination
 }
 
-function deepmerge(target, source, opts) {
+function deepmerge(target, source, inputOptions) {
 	const options = {
-		clone: opts && opts.clone,
-		customMerge: opts && opts.customMerge,
-		arrayMerge: (opts && opts.arrayMerge) || defaultArrayMerge,
-		isMergeable: (opts && opts.isMergeable) || defaultIsMergeable,
+		arrayMerge: defaultArrayMerge,
+		isMergeable: defaultIsMergeable,
+		...inputOptions,
 		// cloneUnlessOtherwiseSpecified is added to `options` so that custom arrayMerge()
 		// implementations can use it. The caller may not replace it.
 		cloneUnlessOtherwiseSpecified: cloneUnlessOtherwiseSpecified

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const mergeObject = (target, source, options) => {
 	return destination
 }
 
-function deepmerge(target, source, inputOptions) {
+const deepmerge = (target, source, inputOptions) => {
 	const options = {
 		arrayMerge: defaultArrayMerge,
 		isMergeable: defaultIsMergeable,

--- a/test/merge.js
+++ b/test/merge.js
@@ -667,3 +667,12 @@ test('Falsey properties should be mergeable', function(t) {
 	t.ok(customMergeWasCalled, 'custom merge function was called')
 	t.end()
 })
+
+test('should not mutate options', function(t) {
+	var options = {}
+
+	merge({}, {}, options)
+
+	t.deepEqual(options, {})
+	t.end()
+})


### PR DESCRIPTION
#167 (Stops mutating options object) was reverted due to #171 (IE 11 regression).

I re-implemented the functionality without using Object.assign.