### PR TITLE
Add arrayMergeStrategies

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,4 +103,27 @@ deepmerge.all = function deepmergeAll(array, options) {
 	}, {})
 }
 
+const combineMerge = (target, source, options) => {
+	const destination = target.slice()
+
+	source.forEach((item, index) => {
+		if (typeof destination[index] === 'undefined') {
+			destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+		} else if (options.isMergeableObject(item)) {
+			destination[index] = merge(target[index], item, options)
+		} else if (target.indexOf(item) === -1) {
+			destination.push(item)
+		}
+	})
+	return destination
+}
+
+const overwriteMerge = (destinationArray, sourceArray, options) => sourceArray
+
+deepmerge.arrayMergeStrategies = {
+	default: defaultArrayMerge,
+	combineMerge,
+	overwriteMerge
+}
+
 module.exports = deepmerge

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,7 +328,7 @@
         "esprima": "^2.7.3",
         "estraverse": "^4.2.0",
         "marked": "^0.7.0",
-        "v8-argv": "github:jkroso/v8-argv#1.1.1"
+        "v8-argv": "github:jkroso/v8-argv#284f84379e292eb956a5e7b66fb953ec4974385e"
       }
     },
     "levn": {

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,13 @@ merge(
 	[3, 2, 1],
 	{ arrayMerge: overwriteMerge }
 ) // => [3, 2, 1]
+
+// use the built in version of this function
+// merge(
+// 	[1, 2, 3],
+// 	[3, 2, 1],
+// 	{ arrayMerge: merge.arrayMergeStrategies.overwriteMerge }
+// )
 ```
 
 #### `arrayMerge` example: combine arrays
@@ -153,6 +160,13 @@ merge(
 	[{ b: true }, 'ah yup'],
 	{ arrayMerge: combineMerge }
 ) // => [{ a: true, b: true }, 'ah yup']
+
+// use the built in version of this function
+// merge(
+// 	[1, 2, 3],
+// 	[3, 2, 1],
+// 	{ arrayMerge: merge.arrayMergeStrategies.combineMerge }
+// )
 ```
 
 ### `isMergeableObject`


### PR DESCRIPTION
Add arrayMergeStrategies named export for easy reference of the functions described in the readme. This allows the user to easily reference the most common functions used in the arrayMerge config option by using `merge.arrayMergeStrategies.combineMerge`