### PR TITLE
Fix merging with empty values

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,14 @@ function mergeObject(target, source, options) {
 			return
 		}
 
-		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
-			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
+		if (propertyIsOnObject(target, key)) {
+			if (options.isEmpty && options.isEmpty(source[key])) {
+				destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
+			} else if (options.isMergeableObject(source[key])) {
+				destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
+			} else {
+				destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
+			}
 		} else {
 			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
 		}


### PR DESCRIPTION
Adds isEmpty option. Then the following code
```
const newObject = {
  foo: {
    one: null,
    two: "New text",
    three: ""
  }
}

const defaultObject = {
  foo: {
    one: "Some default text",
    two: "Some other default text",
    three: "Even more default text"
  }
}

const mergedObject = deepmerge(defaultObject, newObject, {
  isEmpty: a => a === null || a === '',
});
console.log(mergedObject);
```
gives you 
```
{ 
  foo: { 
    one: 'Some default text',
     two: 'New text',
     three: 'Even more default text' 
  } 
}
```