### PR TITLE
Add cloneUnlessOtherwiseSpecified to Options type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare namespace deepmerge {
 		clone?: boolean;
 		customMerge?: (key: string, options?: Options) => ((x: any, y: any) => any) | undefined;
 		isMergeableObject?(value: object): boolean;
+		cloneUnlessOtherwiseSpecified?: (item: any, options?: Options) => any;
 	}
 
 	export function all (objects: object[], options?: Options): object;


### PR DESCRIPTION
`cloneUnlessOtherwiseSpecified` was added to the options object in https://github.com/TehShrike/deepmerge/pull/165 but they forgot to add it to the `Options` type.