### PR TITLE
#185 change customMerge signature for merging empty values

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,4 +103,8 @@ deepmerge.all = function deepmergeAll(array, options) {
 	}, {})
 }
 
+deepmerge.customMergeIgnoreEmptyValues = (key, target, source) => !target || target === ''
+	? () => source
+	: () => target;
+
 module.exports = deepmerge

--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ function defaultArrayMerge(target, source, options) {
 	})
 }
 
-function getMergeFunction(key, options) {
+function getMergeFunction(key, options, target, source) {
 	if (!options.customMerge) {
 		return deepmerge
 	}
-	var customMerge = options.customMerge(key)
+	var customMerge = options.customMerge(key, target, source);
 	return typeof customMerge === 'function' ? customMerge : deepmerge
 }
 
@@ -59,16 +59,16 @@ function mergeObject(target, source, options) {
 		})
 	}
 	getKeys(source).forEach(function(key) {
-		if (propertyIsUnsafe(target, key)) {
-			return
-		}
+			if (propertyIsUnsafe(target, key)) {
+				return
+			}
 
-		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
-			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
-		} else {
-			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
+			if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+				destination[key] = getMergeFunction(key, options, target[key], source[key])(target[key], source[key], options);
+			} else
+				destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
 		}
-	})
+	);
 	return destination
 }
 

--- a/index.js
+++ b/index.js
@@ -59,16 +59,15 @@ function mergeObject(target, source, options) {
 		})
 	}
 	getKeys(source).forEach(function(key) {
-			if (propertyIsUnsafe(target, key)) {
-				return
-			}
-
-			if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
-				destination[key] = getMergeFunction(key, options, target[key], source[key])(target[key], source[key], options);
-			} else
-				destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+		if (propertyIsUnsafe(target, key)) {
+			return
 		}
-	);
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options, target[key], source[key])(target[key], source[key], options);
+		} else
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+	});
 	return destination
 }
 

--- a/test/merge.js
+++ b/test/merge.js
@@ -673,7 +673,7 @@ test('customMerge without overwriting with null or empty string', function(t) {
 	var target = { very: { nested: { thing: 'derp' } } };
 
 	var res = merge(target, src, {
-		customMerge: (key, target, source) => !target || target === '' ? () => source : () => target,
+		customMerge: merge.customMergeIgnoreEmptyValues,
 	});
 
 	t.deepEqual(res, { someNewVariable: 'herp',very: {nested: { thing: 'derp'}} })

--- a/test/merge.js
+++ b/test/merge.js
@@ -667,3 +667,15 @@ test('Falsey properties should be mergeable', function(t) {
 	t.ok(customMergeWasCalled, 'custom merge function was called')
 	t.end()
 })
+
+test('customMerge without overwriting with null or empty string', function(t) {
+	var src = { someNewVariable: 'herp',very: { nested: { thing: '' }} }
+	var target = { very: { nested: { thing: 'derp' } } };
+
+	var res = merge(target, src, {
+		customMerge: (key, target, source) => !target || target === '' ? () => source : () => target,
+	});
+
+	t.deepEqual(res, { someNewVariable: 'herp',very: {nested: { thing: 'derp'}} })
+	t.end()
+})


### PR DESCRIPTION
change customMerge signature to allow for ignoring null or empty string overwrites.
ref: https://github.com/TehShrike/deepmerge/pull/185#issuecomment-703910705 

i think it would be nice to just have a ignoreEmpty optional flag but i threw in a util function there so this ain't so bad is it?