### PR TITLE
Apply clone option to target object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function emptyTarget(val) {
 }
 
 function firstArrayEntry(arr) {
-	return arr[0] && arr[0].length ? arr[0] : []
+	return arr && arr.length ? arr[0] : []
 }
 
 function cloneUnlessOtherwiseSpecified(value, options) {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function propertyIsUnsafe(target, key) {
 
 // Retrieves either a new object or the appropriate target object to mutate.
 function getDestinationObject(target, options) {
-	if (options && !!options.mergeWithTarget) {
+	if (options && options.mergeWithTarget) {
 		return Array.isArray(target) ? firstArrayEntry(target) : target
 	}
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ function emptyTarget(val) {
 	return Array.isArray(val) ? [] : {}
 }
 
+function firstArrayEntry(arr) {
+	return arr[0] && arr[0].length ? arr : []
+}
+
 function cloneUnlessOtherwiseSpecified(value, options) {
 	return (options.clone !== false && options.isMergeableObject(value))
 		? deepmerge(emptyTarget(value), value, options)
@@ -51,9 +55,17 @@ function propertyIsUnsafe(target, key) {
 			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
 }
 
+// Retrieves either a new object or the appropriate target object to mutate.
+function getDestinationObject(target, options) {
+	if (options && options.clone !== false) {
+		return {}
+	}
+
+	return Array.isArray(target) ? firstArrayEntry(target) : target
+}
+
 function mergeObject(target, source, options) {
-	// Modify target object if clone set to false
-	var destination = options.clone === false ? target : {}
+	var destination = getDestinationObject(target, options)
 	if (options.isMergeableObject(target)) {
 		getKeys(target).forEach(function(key) {
 			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
@@ -101,7 +113,7 @@ deepmerge.all = function deepmergeAll(array, options) {
 
 	return array.reduce(function(prev, next) {
 		return deepmerge(prev, next, options)
-	}, {})
+	}, getDestinationObject(array, options))
 }
 
 module.exports = deepmerge

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function propertyIsUnsafe(target, key) {
 
 // Retrieves either a new object or the appropriate target object to mutate.
 function getDestinationObject(target, options) {
-	if (options && !!options.cloneWithTarget) {
+	if (options && !!options.mergeWithTarget) {
 		return Array.isArray(target) ? firstArrayEntry(target) : target
 	}
 

--- a/index.js
+++ b/index.js
@@ -56,16 +56,20 @@ function propertyIsUnsafe(target, key) {
 }
 
 // Retrieves either a new object or the appropriate target object to mutate.
-function getDestinationObject(target, options) {
-	if (options && options.mergeWithTarget) {
+function getDestinationObject(target, source, options) {
+	const targetDefined = typeof target !== 'undefined'
+	const isArray = Array.isArray(target) || Array.isArray(source)
+	const doMerge = options && (options.mergeWithTarget || options.clone === false)
+
+	if (targetDefined && doMerge) {
 		return Array.isArray(target) ? firstArrayEntry(target) : target
 	}
 
-	return {}
+	return isArray ? [] : {};
 }
 
 function mergeObject(target, source, options) {
-	var destination = getDestinationObject(target, options)
+	var destination = getDestinationObject(target, source, options)
 	if (options.isMergeableObject(target)) {
 		getKeys(target).forEach(function(key) {
 			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
@@ -113,7 +117,7 @@ deepmerge.all = function deepmergeAll(array, options) {
 
 	return array.reduce(function(prev, next) {
 		return deepmerge(prev, next, options)
-	}, getDestinationObject(array, options))
+	}, getDestinationObject(array, undefined, options))
 }
 
 module.exports = deepmerge

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ function propertyIsUnsafe(target, key) {
 }
 
 function mergeObject(target, source, options) {
-	var destination = {}
+	// Modify target object if clone set to false
+	var destination = options.clone === false ? target : {}
 	if (options.isMergeableObject(target)) {
 		getKeys(target).forEach(function(key) {
 			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function emptyTarget(val) {
 }
 
 function firstArrayEntry(arr) {
-	return arr[0] && arr[0].length ? arr : []
+	return arr[0] && arr[0].length ? arr[0] : []
 }
 
 function cloneUnlessOtherwiseSpecified(value, options) {

--- a/index.js
+++ b/index.js
@@ -57,11 +57,11 @@ function propertyIsUnsafe(target, key) {
 
 // Retrieves either a new object or the appropriate target object to mutate.
 function getDestinationObject(target, options) {
-	if (options && options.clone !== false) {
-		return {}
+	if (options && !!options.cloneWithTarget) {
+		return Array.isArray(target) ? firstArrayEntry(target) : target
 	}
 
-	return Array.isArray(target) ? firstArrayEntry(target) : target
+	return {}
 }
 
 function mergeObject(target, source, options) {

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,6 +1,30 @@
 var merge = require('../')
 var test = require('tape')
 
+test('result should retain target type information when not cloning', function(t) {
+	var src = { key1: 'value1', key2: 'value2' }
+	class CustomType {}
+	var target = new CustomType()
+
+	var res = merge(target, src, {clone: false})
+	t.not(src instanceof CustomType)
+	t.assert(target instanceof CustomType)
+	t.assert(res instanceof CustomType)
+	t.end()
+})
+
+test('modify target object if clone set to false', function(t) {
+	var src = { key1: 'value1', key2: 'value2' }
+	var target = { key3: 'value3'}
+
+	var clonedRes = merge(target, src, {clone: true})
+	var notClonedRes = merge(target, src, {clone: false})
+
+	t.assert(clonedRes !== target, 'result should be cloned')
+	t.assert(notClonedRes === target, 'result should maintain target reference')
+	t.end()
+})
+
 test('add keys in target that do not exist at the root', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = {}

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,36 +1,36 @@
 var merge = require('../')
 var test = require('tape')
 
-test('result should retain target type information when cloneWithTarget set to true', function(t) {
+test('result should retain target type information when mergeWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	class CustomType {}
 	var target = new CustomType()
 
-	var res = merge(target, src, {cloneWithTarget: true})
+	var res = merge(target, src, {mergeWithTarget: true})
 	t.not(src instanceof CustomType)
 	t.assert(target instanceof CustomType)
 	t.assert(res instanceof CustomType)
 	t.end()
 })
 
-test('modify target object if cloneWithTarget set to true', function(t) {
+test('modify target object if mergeWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = { key3: 'value3'}
 
 	var clonedRes = merge(target, src)
-	var notClonedRes = merge(target, src, {cloneWithTarget: true})
+	var notClonedRes = merge(target, src, {mergeWithTarget: true})
 
 	t.assert(clonedRes !== target, 'result should be cloned')
 	t.assert(notClonedRes === target, 'result should maintain target reference')
 	t.end()
 })
 
-test('merge.all mutates target object when cloneWithTarget set to true', function(t) {
+test('merge.all mutates target object when mergeWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = { key3: 'value3'}
 
 	var clonedRes = merge.all([target, src])
-	var notClonedRes = merge.all([target, src], {cloneWithTarget: true})
+	var notClonedRes = merge.all([target, src], {mergeWithTarget: true})
 
 	t.assert(clonedRes !== target, 'result should be cloned')
 	t.assert(notClonedRes === target, 'result should maintain first array entry reference')

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,6 +1,18 @@
 var merge = require('../')
 var test = require('tape')
 
+test('should handle an undefined value in the target object when merging', function(t) {
+	var src = { key1: 'value1', key2: { key4: 'value4'}, key3: ['value3'] }
+	var target = { key1: 'value', key2: undefined, key3: undefined }
+
+	var notClonedRes = merge(target, src, {mergeWithTarget: true})
+
+	t.assert(notClonedRes === target, 'should successfully merge mutating target');
+	t.assert(notClonedRes.key2 instanceof Object, 'should successfully merge object');
+	t.assert(Array.isArray(notClonedRes.key3), 'should successfully merge array');
+	t.end()
+})
+
 test('result should retain target type information when mergeWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	class CustomType {}

--- a/test/merge.js
+++ b/test/merge.js
@@ -2,14 +2,23 @@ var merge = require('../')
 var test = require('tape')
 
 test('should handle an undefined value in the target object when merging', function(t) {
-	var src = { key1: 'value1', key2: { key4: 'value4'}, key3: ['value3'] }
-	var target = { key1: 'value', key2: undefined, key3: undefined }
+	var src = { key1: 'value1', key2: { key4: 'value4'}, key3: ['value3'], key5: undefined }
+	var target = { key1: 'value', key2: undefined, key3: undefined, key5: ['value5'], key6: ['value6'], key7: { key8: 'value8'} }
 
 	var notClonedRes = merge(target, src, {mergeWithTarget: true})
 
-	t.assert(notClonedRes === target, 'should successfully merge mutating target');
-	t.assert(notClonedRes.key2 instanceof Object, 'should successfully merge object');
-	t.assert(Array.isArray(notClonedRes.key3), 'should successfully merge array');
+	// Undefined target
+	t.assert(notClonedRes.key2 === target.key2, 'should merge object source into undefined value');
+	t.assert(notClonedRes.key3 === target.key3, 'should merge array source into undefined target');
+	t.assert(typeof notClonedRes.key2 === 'object', 'should retain object type when merging into undefined target');
+	t.assert(Array.isArray(notClonedRes.key3), 'should retain array type when merging into undefined target');
+
+	// Explicit undefined source
+	t.assert(typeof key5 === 'undefined', 'should overwrite value with explicitly undefined value');
+
+	// Not defined source props
+	t.assert(Array.isArray(notClonedRes.key6), 'should preserve target property value when no source value exists');
+	t.assert(typeof notClonedRes.key7 === 'object', 'should preserve target property value when');
 	t.end()
 })
 

--- a/test/merge.js
+++ b/test/merge.js
@@ -25,6 +25,18 @@ test('modify target object if clone set to false', function(t) {
 	t.end()
 })
 
+test('merge.all mutates target object', function(t) {
+	var src = { key1: 'value1', key2: 'value2' }
+	var target = { key3: 'value3'}
+
+	var clonedRes = merge.all([target, src], {clone: true})
+	var notClonedRes = merge.all([target, src], {clone: false})
+
+	t.assert(clonedRes !== target, 'result should be cloned')
+	t.assert(notClonedRes === target, 'result should maintain first array entry reference')
+	t.end()
+})
+
 test('add keys in target that do not exist at the root', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = {}

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,36 +1,36 @@
 var merge = require('../')
 var test = require('tape')
 
-test('result should retain target type information when not cloning', function(t) {
+test('result should retain target type information when cloneWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	class CustomType {}
 	var target = new CustomType()
 
-	var res = merge(target, src, {clone: false})
+	var res = merge(target, src, {cloneWithTarget: true})
 	t.not(src instanceof CustomType)
 	t.assert(target instanceof CustomType)
 	t.assert(res instanceof CustomType)
 	t.end()
 })
 
-test('modify target object if clone set to false', function(t) {
+test('modify target object if cloneWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = { key3: 'value3'}
 
-	var clonedRes = merge(target, src, {clone: true})
-	var notClonedRes = merge(target, src, {clone: false})
+	var clonedRes = merge(target, src)
+	var notClonedRes = merge(target, src, {cloneWithTarget: true})
 
 	t.assert(clonedRes !== target, 'result should be cloned')
 	t.assert(notClonedRes === target, 'result should maintain target reference')
 	t.end()
 })
 
-test('merge.all mutates target object', function(t) {
+test('merge.all mutates target object when cloneWithTarget set to true', function(t) {
 	var src = { key1: 'value1', key2: 'value2' }
 	var target = { key3: 'value3'}
 
-	var clonedRes = merge.all([target, src], {clone: true})
-	var notClonedRes = merge.all([target, src], {clone: false})
+	var clonedRes = merge.all([target, src])
+	var notClonedRes = merge.all([target, src], {cloneWithTarget: true})
 
 	t.assert(clonedRes !== target, 'result should be cloned')
 	t.assert(notClonedRes === target, 'result should maintain first array entry reference')

--- a/test/merge.js
+++ b/test/merge.js
@@ -14,11 +14,11 @@ test('should handle an undefined value in the target object when merging', funct
 	t.assert(Array.isArray(notClonedRes.key3), 'should retain array type when merging into undefined target');
 
 	// Explicit undefined source
-	t.assert(typeof key5 === 'undefined', 'should overwrite value with explicitly undefined value');
+	t.assert(typeof key5 === 'undefined', 'should overwrite target value with explicitly undefined source value');
 
 	// Not defined source props
 	t.assert(Array.isArray(notClonedRes.key6), 'should preserve target property value when no source value exists');
-	t.assert(typeof notClonedRes.key7 === 'object', 'should preserve target property value when');
+	t.assert(typeof notClonedRes.key7 === 'object', 'should preserve target property value when no source value exists');
 	t.end()
 })
 


### PR DESCRIPTION
closes #208 
closes #186 

* Added ternary for initializing the `destination` object based on the `clone` option.
* Added 2 unit tests... 1 to test that target type info is retained, and another to ensure that target memory pointer is maintained when `clone` is set to `false`.