### PR TITLE
Use DeepPartial snippet instead of shallow Partial

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
-declare function deepmerge<T>(x: Partial<T>, y: Partial<T>, options?: deepmerge.Options): T;
-declare function deepmerge<T1, T2>(x: Partial<T1>, y: Partial<T2>, options?: deepmerge.Options): T1 & T2;
+type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+declare function deepmerge<T>(x: DeepPartial<T>, y: DeepPartial<T>, options?: deepmerge.Options): T;
+declare function deepmerge<T1, T2>(x: DeepPartial<T1>, y: DeepPartial<T2>, options?: deepmerge.Options): T1 & T2;
 
 declare namespace deepmerge {
 	export interface Options {


### PR DESCRIPTION
In the spirit of the library, allow the typing support to use a deep partial instead of a shallow partial, removing type errors when reconstructing an object from a deep partial