### PR TITLE
Add ArrayMergeOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,14 @@ declare function deepmerge<T1, T2>(x: Partial<T1>, y: Partial<T2>, options?: dee
 
 declare namespace deepmerge {
 	export interface Options {
-		arrayMerge?(target: any[], source: any[], options?: Options): any[];
+		arrayMerge?(target: any[], source: any[], options?: ArrayMergeOptions): any[];
 		clone?: boolean;
 		customMerge?: (key: string, options?: Options) => ((x: any, y: any) => any) | undefined;
 		isMergeableObject?(value: object): boolean;
+	}
+	export interface ArrayMergeOptions {
+		isMergeableObject(value: object): boolean;
+		cloneUnlessOtherwiseSpecified(value: object, options?: Options): object;
 	}
 
 	export function all (objects: object[], options?: Options): object;


### PR DESCRIPTION
Since the `cloneUnlessOtherwiseSpecified` function wasn't part of the `Options` interface, it couldn't be called in a TypeScript project even though it is passed to the `arrayMerge` callback on its `options` object.

Addresses an issue with a previous attempt to address this issue (#231) that it didn't define the `arrayMerge`'s options independently from the existing `Options` interface even though the two are distinct.