### PR TITLE
improve performance of merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,17 +36,9 @@ function getKeys(target) {
 	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
 }
 
-function propertyIsOnObject(object, property) {
-	try {
-		return property in object
-	} catch(_) {
-		return false
-	}
-}
-
 // Protects from prototype poisoning and unexpected merging up the prototype chain.
 function propertyIsUnsafe(target, key) {
-	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+	return key in target // Properties are safe to merge if they don't exist in the target yet,
 		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
 			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
 }
@@ -58,12 +50,18 @@ function mergeObject(target, source, options) {
 			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
 		})
 	}
+
+	if (typeof target !== 'object' || target === null) {
+		destination = cloneUnlessOtherwiseSpecified(source, options)
+		return destination;
+	}
+
 	getKeys(source).forEach(function(key) {
 		if (propertyIsUnsafe(target, key)) {
 			return
 		}
 
-		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+		if (key in target && options.isMergeableObject(source[key])) {
 			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
 		} else {
 			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)


### PR DESCRIPTION
master:
uzlopak@Battlestation:~/workspace/deepmerge$ node benchmark.js 
merge existing simple keys in target at the roots x 1,532,019 ops/sec ±1.78% (83 runs sampled)
merge nested objects into target x 28,632 ops/sec ±1.05% (76 runs sampled)

this branch:
uzlopak@Battlestation:~/workspace/deepmerge$ node benchmark.js 
merge existing simple keys in target at the roots x 1,540,510 ops/sec ±1.36% (87 runs sampled)
merge nested objects into target x 838,991 ops/sec ±1.35% (84 runs sampled)

corresponding benchmark:
```javascript
var Benchmark = require('benchmark');
var merge = require('.');
var suite = new Benchmark.Suite;

var srcSimple = { key1: 'changed', key2: 'value2' }
var targetSimple = { key1: 'value1', key3: 'value3' }


var srcNested = {
    key1: {
        subkey1: 'subvalue1',
        subkey2: 'subvalue2',
    },
}
var targetNested = {
    key1: 'value1',
    key2: 'value2',
}
// add tests
suite.add('merge existing simple keys in target at the roots', function() {
    var res = merge(targetSimple, srcSimple)
})
suite.add('merge nested objects into target', function() {
    var res = merge(targetNested, srcNested)
})
// add listeners
.on('cycle', function(event) {
  console.log(String(event.target));
})
// run async
.run({ 'async': true });
 
```