### PR TITLE
Improve Performance of getKeys

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,12 @@ function getMergeFunction(key, options) {
 }
 
 function getEnumerableOwnPropertySymbols(target) {
-	return Object.getOwnPropertySymbols
-		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
-			return target.propertyIsEnumerable(symbol)
-		})
-		: []
+	var result = [];
+	var keys = Object.getOwnPropertySymbols(target);
+	for (var i = 0, il = keys.length; i < il; ++i) {
+		target.propertyIsEnumerable(keys[i]) && result.push(keys[i]);
+	}
+	return result;
 }
 
 var pushArray = Array.prototype.push;

--- a/index.js
+++ b/index.js
@@ -32,9 +32,15 @@ function getEnumerableOwnPropertySymbols(target) {
 		: []
 }
 
-function getKeys(target) {
-	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
-}
+var pushArray = Array.prototype.push;
+
+var getKeys = Object.getOwnPropertySymbols
+	? function getKeys(target) {
+		var result = Object.keys(target);
+		pushArray.apply(result, getEnumerableOwnPropertySymbols(target))
+		return result
+	}
+	: Object.keys;
 
 function propertyIsOnObject(object, property) {
 	try {

--- a/index.js
+++ b/index.js
@@ -25,23 +25,23 @@ function getMergeFunction(key, options) {
 }
 
 function getEnumerableOwnPropertySymbols(target) {
-	var result = [];
-	var keys = Object.getOwnPropertySymbols(target);
+	var result = []
+	var keys = Object.getOwnPropertySymbols(target)
 	for (var i = 0, il = keys.length; i < il; ++i) {
-		target.propertyIsEnumerable(keys[i]) && result.push(keys[i]);
+		target.propertyIsEnumerable(keys[i]) && result.push(keys[i])
 	}
-	return result;
+	return result
 }
 
-var pushArray = Array.prototype.push;
+var pushArray = Array.prototype.push
 
 var getKeys = Object.getOwnPropertySymbols
 	? function getKeys(target) {
-		var result = Object.keys(target);
+		var result = Object.keys(target)
 		pushArray.apply(result, getEnumerableOwnPropertySymbols(target))
 		return result
 	}
-	: Object.keys;
+	: Object.keys
 
 function propertyIsOnObject(object, property) {
 	try {


### PR DESCRIPTION
master:
merge existing simple keys in target at the roots x 1,547,519 ops/sec ±1.55% (83 runs sampled)

this:
merge existing simple keys in target at the roots x 2,557,243 ops/sec ±1.36% (87 runs sampled)

benchmark:
```javascript

var Benchmark = require('benchmark');
var merge = require('.');
var suite = new Benchmark.Suite;

var srcSimple = { key1: 'changed', key2: 'value2' }
var targetSimple = { key1: 'value1', key3: 'value3' }

// add tests
suite.add('merge existing simple keys in target at the roots', function() {
    var res = merge(targetSimple, srcSimple)
})
// add listeners
.on('cycle', function(event) {
  console.log(String(event.target));
})
// run async
.run({ 'async': true });
 
```