### PR TITLE
Prevent getEnumerableOwnPropertySymbols from throwing when target.propertyIsEnumerable is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function getMergeFunction(key, options) {
 function getEnumerableOwnPropertySymbols(target) {
 	return Object.getOwnPropertySymbols
 		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
-			return target.propertyIsEnumerable(symbol)
+			return Object.propertyIsEnumerable.call(target, symbol)
 		})
 		: []
 }


### PR DESCRIPTION
This changeset prevents `getEnumerableOwnPropertySymbols()` from throwing when `target.propertyIsEnumerable` is undefined. It follows the same convention of `Object.propertyIsEnumerable.call(target, key)` that is used a few lines below.